### PR TITLE
fix: guard supabase client env configuration

### DIFF
--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,36 +1,61 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient as SupabaseJsClient } from '@supabase/supabase-js';
 import { Database } from '@/types/supabase';
 
-// Environment variables with fallbacks to prevent bundler errors
-const supabaseUrl =
-  process.env.NEXT_PUBLIC_SUPABASE_URL ||
-  'https://vqtfcdnrgotgrnwwuryo.supabase.co';
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
+let cachedClient: SupabaseJsClient<Database> | null = null;
 
-// Runtime validation for production
-if (typeof window !== 'undefined') {
-  if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
-    console.error('Missing NEXT_PUBLIC_SUPABASE_URL environment variable');
-  }
-  if (!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
-    console.error('Missing NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable');
-  }
-}
+const ensureEnvironment = () => {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-// Initialize the Supabase client with TypeScript support
-export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey, {
-  auth: {
-    persistSession: true,
-    autoRefreshToken: true,
-    detectSessionInUrl: true,
-    flowType: 'pkce',
-  },
-  realtime: {
-    params: {
-      eventsPerSecond: 10,
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error(
+      'Supabase environment variables are missing. Please set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.'
+    );
+  }
+
+  return { supabaseUrl, supabaseAnonKey };
+};
+
+const createSupabaseClient = () => {
+  const { supabaseUrl, supabaseAnonKey } = ensureEnvironment();
+
+  return createClient<Database>(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+      flowType: 'pkce',
     },
-  },
-});
+    realtime: {
+      params: {
+        eventsPerSecond: 10,
+      },
+    },
+  });
+};
 
-// Export types for convenience
-export type SupabaseClient = typeof supabase;
+export const getSupabaseClient = (): SupabaseJsClient<Database> => {
+  if (!cachedClient) {
+    cachedClient = createSupabaseClient();
+  }
+
+  return cachedClient;
+};
+
+export const supabase = new Proxy(
+  {} as SupabaseJsClient<Database>,
+  {
+    get(_target, prop, receiver) {
+      const client = getSupabaseClient();
+      const value = Reflect.get(client, prop, receiver);
+
+      if (typeof value === 'function') {
+        return value.bind(client);
+      }
+
+      return value;
+    },
+  }
+) as SupabaseJsClient<Database>;
+
+export type SupabaseClient = SupabaseJsClient<Database>;

--- a/tests/supabase-client.spec.ts
+++ b/tests/supabase-client.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+const moduleRelativePath = './src/lib/supabase/client.ts';
+
+const runNodeScript = (code: string) => {
+  const env = { ...process.env };
+  delete env.NEXT_PUBLIC_SUPABASE_URL;
+  delete env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  return spawnSync('node', ['-r', 'ts-node/register/transpile-only', '-e', code], {
+    cwd: projectRoot,
+    env,
+    encoding: 'utf-8',
+  });
+};
+
+test.describe('supabase client environment guards', () => {
+  test('module evaluates without supabase env vars', async () => {
+    const script = `require('${moduleRelativePath}');`;
+    const result = runNodeScript(script);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+  });
+
+  test('getSupabaseClient throws a helpful error when env vars are missing', async () => {
+    const script = String.raw`
+const { getSupabaseClient } = require('${moduleRelativePath}');
+try {
+  getSupabaseClient();
+  console.error('Expected getSupabaseClient to throw');
+  process.exit(1);
+} catch (error) {
+  if (error instanceof Error) {
+    console.log(error.message);
+  } else {
+    console.log(String(error));
+  }
+}
+`;
+
+    const result = runNodeScript(script);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      'Supabase environment variables are missing. Please set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.'
+    );
+  });
+});

--- a/types/playwright-test.d.ts
+++ b/types/playwright-test.d.ts
@@ -1,0 +1,21 @@
+declare module '@playwright/test' {
+  interface TestInterface {
+    (name: string, fn: (args: any) => any): any;
+    describe: TestInterface & {
+      configure: (...args: any[]) => any;
+      skip: TestInterface;
+      only: TestInterface;
+    };
+    beforeAll: (...args: any[]) => any;
+    beforeEach: (...args: any[]) => any;
+    afterAll: (...args: any[]) => any;
+    afterEach: (...args: any[]) => any;
+    step: (...args: any[]) => any;
+    use: (...args: any[]) => any;
+  }
+
+  export const test: TestInterface;
+  export const expect: any;
+  export const defineConfig: (...args: any[]) => any;
+  export const devices: Record<string, any>;
+}


### PR DESCRIPTION
## Summary
- lazily initialize the Supabase client only when both public URL and anon key environment variables are present
- expose a cached `getSupabaseClient` helper while keeping the existing `supabase` export via a proxy wrapper
- add a Playwright smoke test that spawns a Node process to ensure the module loads without env vars and surfaces a clear error when the client is requested
- stub the `@playwright/test` module types so the stricter TypeScript configuration accepts the new tests

## Testing
- pnpm run type-check

------
https://chatgpt.com/codex/tasks/task_b_68d30604e168832e903d8ee0f6171bd0